### PR TITLE
Allow configuring device filter in settings

### DIFF
--- a/App/iOS/Esp32 Controller/Esp32 Controller/BluetoothManager.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/BluetoothManager.swift
@@ -2,11 +2,17 @@ import Foundation
 import CoreBluetooth
 
 class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
+    private static let deviceFilterDefaultsKey = "bluetooth.deviceFilterName"
+
     @Published var isConnected = false
     @Published var discoveredDevices: [CBPeripheral] = []
     @Published var isScanning = false
-    
-    @Published var deviceName: String = "ESP32Roomba"
+
+    @Published var deviceName: String = UserDefaults.standard.string(forKey: BluetoothManager.deviceFilterDefaultsKey) ?? "ESP32Roomba" {
+        didSet {
+            UserDefaults.standard.set(deviceName, forKey: BluetoothManager.deviceFilterDefaultsKey)
+        }
+    }
     
     @Published var connectedPeripheral: CBPeripheral?
 

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/SettingsView.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/SettingsView.swift
@@ -9,9 +9,39 @@ import SwiftUI
 
 struct SettingsView: View {
     @ObservedObject var bleManager: BluetoothManager
+    @State private var deviceFilter: String
+
+    init(bleManager: BluetoothManager) {
+        self._bleManager = ObservedObject(wrappedValue: bleManager)
+        self._deviceFilter = State(initialValue: bleManager.deviceName)
+    }
+
     var body: some View {
-        HStack {
-            
+        Form {
+            Section("Device Filter") {
+                TextField("Device name", text: $deviceFilter)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+
+                Text("Only devices whose Bluetooth name matches this filter will appear on the connection screen.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
+            Section {
+                Button("Reset to Default") {
+                    deviceFilter = "ESP32Roomba"
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        .onAppear {
+            deviceFilter = bleManager.deviceName
+        }
+        .onChange(of: deviceFilter) { newValue in
+            if bleManager.deviceName != newValue {
+                bleManager.deviceName = newValue
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist the Bluetooth device filter name in `UserDefaults` so the last choice is reused
- add a Settings screen form to edit the device name filter and reset it to the default

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbf5ed0a8083258b1ba6459468104e