### PR TITLE
Add configurable robot controller presets and selection UI

### DIFF
--- a/App/iOS/Esp32 Controller/Esp32 Controller/BluetoothManager.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/BluetoothManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreBluetooth
+import SwiftUI
 
 class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CBPeripheralDelegate {
     private static let deviceFilterDefaultsKey = "bluetooth.deviceFilterName"
@@ -11,6 +12,13 @@ class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CB
     @Published var deviceName: String = UserDefaults.standard.string(forKey: BluetoothManager.deviceFilterDefaultsKey) ?? "ESP32Roomba" {
         didSet {
             UserDefaults.standard.set(deviceName, forKey: BluetoothManager.deviceFilterDefaultsKey)
+        }
+    }
+
+    private static let profileDefaultsKey = "bluetooth.robotProfile"
+    @Published var selectedProfile: RobotProfile = RobotProfile(rawValue: UserDefaults.standard.string(forKey: BluetoothManager.profileDefaultsKey) ?? RobotProfile.roomba.rawValue) ?? .roomba {
+        didSet {
+            UserDefaults.standard.set(selectedProfile.rawValue, forKey: BluetoothManager.profileDefaultsKey)
         }
     }
     

--- a/App/iOS/Esp32 Controller/Esp32 Controller/RobotProfile.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/RobotProfile.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+struct RobotModeOption: Identifiable, Equatable {
+    let id: String
+    let title: String
+    let caption: String?
+    let command: RobotCommand
+
+    init(id: String, title: String, caption: String? = nil, command: RobotCommand) {
+        self.id = id
+        self.title = title
+        self.caption = caption
+        self.command = command
+    }
+}
+
+struct RobotQuickAction: Identifiable {
+    enum ActionType {
+        case momentary(command: RobotCommand)
+        case toggle(defaultState: Bool, on: RobotCommand, off: RobotCommand)
+        case roombaMotor(RobotMotorKind)
+    }
+
+    let id: String
+    let title: String
+    let iconName: String
+    let type: ActionType
+
+    init(id: String, title: String, iconName: String, type: ActionType) {
+        self.id = id
+        self.title = title
+        self.iconName = iconName
+        self.type = type
+    }
+}
+
+enum RobotCommand {
+    case text(String)
+    case roombaBytes([UInt8])
+}
+
+enum RobotMotorKind: String, CaseIterable, Identifiable {
+    case vacuum
+    case sideBrush
+    case mainBrush
+
+    var id: String { rawValue }
+}
+
+enum RobotProfile: String, CaseIterable, Identifiable {
+    case generic
+    case roomba
+    case tank
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .generic:
+            return "Universal"
+        case .roomba:
+            return "Roomba"
+        case .tank:
+            return "Tracked Tank"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .generic:
+            return "Simple button presets for any ESP32-based robot."
+        case .roomba:
+            return "Tailored controls for iRobot Roomba vacuums using the Open Interface."
+        case .tank:
+            return "Preset commands for a differential drive tank with lights and accessories."
+        }
+    }
+
+    var accentColor: Color {
+        switch self {
+        case .generic:
+            return .blue
+        case .roomba:
+            return .green
+        case .tank:
+            return .orange
+        }
+    }
+
+    var modeOptions: [RobotModeOption] {
+        switch self {
+        case .generic:
+            return [
+                RobotModeOption(id: "manual", title: "Manual", caption: "Direct drive with joystick", command: .text("MODE:MANUAL")),
+                RobotModeOption(id: "assist", title: "Assist", caption: "Joystick + onboard assists", command: .text("MODE:ASSIST"))
+            ]
+        case .roomba:
+            return [
+                RobotModeOption(id: "safe", title: "Safe", caption: "Limits the motors", command: .roombaBytes([131])),
+                RobotModeOption(id: "full", title: "Full", caption: "No safety limits", command: .roombaBytes([132]))
+            ]
+        case .tank:
+            return [
+                RobotModeOption(id: "precision", title: "Precision", caption: "Slow, accurate movements", command: .text("MODE:PRECISION")),
+                RobotModeOption(id: "turbo", title: "Turbo", caption: "Full power driving", command: .text("MODE:TURBO"))
+            ]
+        }
+    }
+
+    var defaultMode: RobotModeOption? {
+        modeOptions.first
+    }
+
+    var quickActions: [RobotQuickAction] {
+        switch self {
+        case .generic:
+            return [
+                RobotQuickAction(
+                    id: "generic.b1",
+                    title: "Light",
+                    iconName: "lightbulb",
+                    type: .toggle(defaultState: false, on: .text("B1:ON"), off: .text("B1:OFF"))
+                ),
+                RobotQuickAction(
+                    id: "generic.b2",
+                    title: "Horn",
+                    iconName: "speaker.wave.3",
+                    type: .momentary(command: .text("B2:TRIGGER"))
+                ),
+                RobotQuickAction(
+                    id: "generic.b3",
+                    title: "Macro",
+                    iconName: "bolt",
+                    type: .momentary(command: .text("B3:RUN"))
+                )
+            ]
+        case .roomba:
+            return [
+                RobotQuickAction(
+                    id: "roomba.vacuum",
+                    title: "Vacuum",
+                    iconName: "tornado",
+                    type: .roombaMotor(.vacuum)
+                ),
+                RobotQuickAction(
+                    id: "roomba.sideBrush",
+                    title: "Side Brush",
+                    iconName: "fan",
+                    type: .roombaMotor(.sideBrush)
+                ),
+                RobotQuickAction(
+                    id: "roomba.mainBrush",
+                    title: "Main Brush",
+                    iconName: "paintbrush",
+                    type: .roombaMotor(.mainBrush)
+                ),
+                RobotQuickAction(
+                    id: "roomba.dock",
+                    title: "Dock",
+                    iconName: "house",
+                    type: .momentary(command: .roombaBytes([143]))
+                )
+            ]
+        case .tank:
+            return [
+                RobotQuickAction(
+                    id: "tank.headlights",
+                    title: "Headlights",
+                    iconName: "car.headlights",
+                    type: .toggle(defaultState: false, on: .text("LIGHTS:ON"), off: .text("LIGHTS:OFF"))
+                ),
+                RobotQuickAction(
+                    id: "tank.turret",
+                    title: "Turret",
+                    iconName: "scope",
+                    type: .momentary(command: .text("TURRET:FIRE"))
+                ),
+                RobotQuickAction(
+                    id: "tank.smoke",
+                    title: "Smoke",
+                    iconName: "smoke",
+                    type: .toggle(defaultState: false, on: .text("SMOKE:ON"), off: .text("SMOKE:OFF"))
+                ),
+                RobotQuickAction(
+                    id: "tank.anchor",
+                    title: "Anchor",
+                    iconName: "lifepreserver",
+                    type: .momentary(command: .text("ANCHOR:DEPLOY"))
+                )
+            ]
+        }
+    }
+
+    var joystickTip: String {
+        switch self {
+        case .generic:
+            return "Use the joystick to stream normalized X/Y commands to your firmware."
+        case .roomba:
+            return "Joystick commands are translated into Roomba velocity/radius strings."
+        case .tank:
+            return "Differential drive: push forward to advance, twist to spin in place."
+        }
+    }
+}

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/ConnectingView.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/ConnectingView.swift
@@ -9,12 +9,18 @@ import SwiftUI
 
 struct ConnectingView: View {
     @Environment(\.colorScheme) var colorScheme
-    
+
     @ObservedObject var bleManager: BluetoothManager
 
     @State private var connectionTimer: Timer?
 
-    
+    private var profileBinding: Binding<RobotProfile> {
+        Binding(
+            get: { bleManager.selectedProfile },
+            set: { bleManager.selectedProfile = $0 }
+        )
+    }
+
     var body: some View {
         NavigationStack {
             HStack(spacing: 0) {
@@ -129,7 +135,7 @@ struct ConnectingView: View {
                     VStack {
                         HStack {
                             Spacer()
-                            
+
                             NavigationLink {
                                 SettingsView(bleManager: bleManager)
                             } label: {
@@ -145,10 +151,26 @@ struct ConnectingView: View {
                         
                         
                         Spacer()
-                        
-                        HStack {
-                            Spacer()
-                            
+
+                        VStack(alignment: .trailing, spacing: 12) {
+                            Text("Controller Preset")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+
+                            Picker("Controller Preset", selection: profileBinding) {
+                                ForEach(RobotProfile.allCases) { profile in
+                                    Text(profile.displayName).tag(profile)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .tint(.green)
+
+                            Text(bleManager.selectedProfile.description)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: 240)
+                                .multilineTextAlignment(.trailing)
+
                             NavigationLink {
                                 ControllerView(bleManager: bleManager)
                             } label: {
@@ -158,11 +180,13 @@ struct ConnectingView: View {
                                     .bold()
                                     .padding(.horizontal)
                                     .padding(.vertical, 10)
-                            }.buttonStyle(.borderedProminent)
-                                .tint(.green)
-                                .disabled(!bleManager.isConnected)
-                        }.padding(.trailing)
-                        
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .tint(.green)
+                            .disabled(!bleManager.isConnected)
+                        }
+                        .padding(.trailing)
+
                     }.frame(maxWidth: .infinity)
             }.padding()
             .edgesIgnoringSafeArea(.all)

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/ControllerView.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/ControllerView.swift
@@ -1,201 +1,254 @@
-//
-//  ControllerView.swift
-//  Esp32 Controller
-//
-//  Created by Kryštof Sláma on 21.07.2025.
-//
-
 import SwiftUI
 
 struct ControllerView: View {
     @ObservedObject var bleManager: BluetoothManager
-    
-    @State private var roombaMode: RoombaMode = .safe
-    
-    enum RoombaMode: String, CaseIterable, Identifiable {
-        case safe = "Safe"
-        case full = "Full"
-        var id: String { self.rawValue }
+
+    @State private var selectedModeID: String = ""
+    @State private var quickActionStates: [String: Bool] = [:]
+    @State private var roombaMotorStates: [RobotMotorKind: Bool] = [:]
+    @State private var suppressModeCommand = false
+
+    private var profileBinding: Binding<RobotProfile> {
+        Binding(
+            get: { bleManager.selectedProfile },
+            set: { bleManager.selectedProfile = $0 }
+        )
     }
-    
-    
-    @State private var sideBrushOn = false
-    @State private var mainBrushOn = false
-    @State private var vacuumOn = false
 
     var body: some View {
-        VStack(spacing: 20) {
-            HStack {
-                Button {
-                    bleManager.checkConnection()
-                } label: {
-                    Image(systemName: "arrow.clockwise")
+        let profile = bleManager.selectedProfile
+
+        VStack(alignment: .leading, spacing: 24) {
+            headerView(for: profile)
+
+            if !profile.description.isEmpty {
+                Text(profile.description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(alignment: .top, spacing: 24) {
+                VStack(spacing: 12) {
+                    JoystickView { command in
+                        bleManager.send(command)
+                    }
+                    .padding(.trailing, 8)
+
+                    Text(profile.joystickTip)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: 220)
+                        .multilineTextAlignment(.center)
                 }
-                Text("✅ Connected")
-                    .font(.title2)
-                
-                Spacer()
-                
-                Picker("Mode", selection: $roombaMode) {
-                    ForEach(RoombaMode.allCases) { mode in
-                        Text(mode.rawValue).tag(mode as RoombaMode)
+
+                Spacer(minLength: 24)
+
+                if !profile.quickActions.isEmpty {
+                    quickActionsPanel(for: profile)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Spacer()
+        }
+        .padding()
+        .navigationTitle(profile.displayName)
+        .onAppear {
+            resetState(for: profile)
+        }
+        .onChange(of: bleManager.selectedProfile) { newProfile in
+            resetState(for: newProfile)
+        }
+        .onChange(of: selectedModeID) { newValue in
+            guard !suppressModeCommand,
+                  let mode = bleManager.selectedProfile.modeOptions.first(where: { $0.id == newValue }) else {
+                return
+            }
+            applyMode(mode)
+        }
+    }
+
+    @ViewBuilder
+    private func headerView(for profile: RobotProfile) -> some View {
+        HStack(spacing: 16) {
+            Button {
+                bleManager.checkConnection()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .imageScale(.large)
+            }
+
+            Label {
+                Text(bleManager.isConnected ? "Connected" : "Disconnected")
+                    .font(.headline)
+            } icon: {
+                Image(systemName: bleManager.isConnected ? "checkmark.circle" : "xmark.circle")
+                    .foregroundStyle(bleManager.isConnected ? .green : .red)
+            }
+
+            Spacer()
+
+            if !profile.modeOptions.isEmpty {
+                Picker("Mode", selection: $selectedModeID) {
+                    ForEach(profile.modeOptions) { mode in
+                        Text(mode.title).tag(mode.id)
                     }
                 }
                 .pickerStyle(.segmented)
-                .padding()
-                .frame(width: 200)
-                .onChange(of: roombaMode) { oldMode, newMode in
-                    switch newMode {
-                    case .safe:
-                        print("SAFE Mode")
-                        bleManager.sendRoombaBytes([131]) // SAFE mode
-                    case .full:
-                        print("FULL Mode")
-                        bleManager.sendRoombaBytes([132]) // FULL mode
-                    }
-                }
+                .frame(maxWidth: 300)
+                .accessibilityLabel("Robot mode")
+            }
 
-                
-                Spacer()
-                
-                Button("📡 Dock") {
-                    //bleManager.sendRoombaBytes([143])
+            Picker("Preset", selection: profileBinding) {
+                ForEach(RobotProfile.allCases) { profile in
+                    Text(profile.displayName).tag(profile)
                 }
             }
-            
-            Spacer()
-            
-            
-            
-            
-            HStack {
-                
-                
-                JoystickView { command in
-                    bleManager.send(command)
-                }
-                Spacer()
-                
-                VStack {
-                    HStack {
-                        Button {
-                            vacuumOn.toggle()
-                            motorsControl()
-                        } label: {
-                            ZStack {
-                                Circle()
-                                    .frame(width: 80, height: 80)
-                                    .foregroundStyle(Color(.systemGray4))
-                                
-                                if vacuumOn {
-                                    Image(systemName: "tornado")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundStyle(.black)
-                                        .background(.clear)
-                                } else {
-                                    Image(systemName: "tornado")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundStyle(.black)
-                                        .background(.clear)
-                                }
-                            }
-                        }
-                        .padding()
-                        .cornerRadius(10)
-                    }.padding(.bottom, -40)
-                    HStack {
-                        Button {
-                            sideBrushOn.toggle()
-                            motorsControl()
-                        } label: {
-                            ZStack {
-                                Circle()
-                                    .frame(width: 80, height: 80)
-                                    .foregroundStyle(Color(.systemGray4))
-                                
-                                if sideBrushOn {
-                                    Image(systemName: "fan.fill")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundStyle(.black)
-                                        .background(.clear)
-                                } else {
-                                    Image(systemName: "fan")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundStyle(.black)
-                                        .background(.clear)
-                                }
-                            }
-                        }
-                        .padding()
-                        .cornerRadius(10)
-                        
-                        Spacer()
-                        
-                        Button {
-                            mainBrushOn.toggle()
-                            motorsControl()
-                        } label: {
-                            ZStack {
-                                Circle()
-                                    .frame(width: 80, height: 80)
-                                    .foregroundStyle(Color(.systemGray4))
-                                
-                                if mainBrushOn {
-                                    Image(systemName: "paintbrush.fill")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundStyle(.black)
-                                        .background(.clear)
-                                } else {
-                                    Image(systemName: "paintbrush")
-                                        .resizable()
-                                        .frame(width: 50, height: 50)
-                                        .foregroundStyle(.black)
-                                        .background(.clear)
-                                }
-                            }
-                        }
-                        .padding()
-                        .cornerRadius(10)
-                    }.frame(width: 200)
-                }
-            }
+            .pickerStyle(.menu)
+            .tint(profile.accentColor)
         }
-        .padding()
     }
-    
-    func motorsControl() {
-        let mainByte: UInt8
-        let brushByte: UInt8
-        let vacuumByte: UInt8
-        
-        if mainBrushOn {
-            mainByte = UInt8(4)
-        } else {
-            mainByte = UInt8(0)
+
+    @ViewBuilder
+    private func quickActionsPanel(for profile: RobotProfile) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Quick Actions")
+                .font(.headline)
+
+            let columns = [GridItem(.flexible()), GridItem(.flexible())]
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(profile.quickActions) { action in
+                    Button {
+                        handleQuickAction(action)
+                    } label: {
+                        quickActionContent(for: action, profile: profile)
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!bleManager.isConnected)
+                }
+            }
         }
-        if vacuumOn {
-            vacuumByte = UInt8(2)
-        } else {
-            vacuumByte = UInt8(0)
+    }
+
+    private func quickActionContent(for action: RobotQuickAction, profile: RobotProfile) -> some View {
+        let isOn = actionIsOn(action)
+        return VStack(spacing: 8) {
+            ZStack {
+                Circle()
+                    .fill(isOn ? profile.accentColor.opacity(0.25) : Color(.systemGray4))
+                    .frame(width: 80, height: 80)
+
+                Image(systemName: symbolName(for: action, isOn: isOn))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 42, height: 42)
+                    .foregroundStyle(isOn ? profile.accentColor : .primary)
+            }
+
+            Text(action.title)
+                .font(.subheadline)
+                .foregroundStyle(.primary)
         }
-        if sideBrushOn {
-            brushByte = UInt8(1)
-        } else {
-            brushByte = UInt8(0)
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(action.title)
+        .accessibilityValue(isOn ? "On" : "Off")
+    }
+
+    private func symbolName(for action: RobotQuickAction, isOn: Bool) -> String {
+        switch action.type {
+        case .roombaMotor(let motor):
+            switch motor {
+            case .vacuum:
+                return isOn ? "tornado" : "tornado"
+            case .sideBrush:
+                return isOn ? "fan.fill" : "fan"
+            case .mainBrush:
+                return isOn ? "paintbrush.fill" : "paintbrush"
+            }
+        default:
+            return action.iconName
         }
-        
-        let bits: UInt8 = mainByte + brushByte + vacuumByte
-        print("Sending: \(bits)")
+    }
+
+    private func handleQuickAction(_ action: RobotQuickAction) {
+        switch action.type {
+        case .momentary(let command):
+            send(command)
+
+        case let .toggle(defaultState, onCommand, offCommand):
+            let currentState = quickActionStates[action.id] ?? defaultState
+            let newState = !currentState
+            quickActionStates[action.id] = newState
+            send(newState ? onCommand : offCommand)
+
+        case .roombaMotor(let motor):
+            let current = roombaMotorStates[motor] ?? false
+            roombaMotorStates[motor] = !current
+            sendRoombaMotorBits()
+        }
+    }
+
+    private func actionIsOn(_ action: RobotQuickAction) -> Bool {
+        switch action.type {
+        case .momentary:
+            return false
+        case let .toggle(defaultState, _, _):
+            return quickActionStates[action.id] ?? defaultState
+        case .roombaMotor(let motor):
+            return roombaMotorStates[motor] ?? false
+        }
+    }
+
+    private func sendRoombaMotorBits() {
+        let main = roombaMotorStates[.mainBrush] ?? false
+        let vacuum = roombaMotorStates[.vacuum] ?? false
+        let side = roombaMotorStates[.sideBrush] ?? false
+
+        let bits: UInt8 = (main ? 4 : 0) + (vacuum ? 2 : 0) + (side ? 1 : 0)
         bleManager.sendRoombaBytes([138, bits])
+    }
+
+    private func applyMode(_ mode: RobotModeOption) {
+        send(mode.command)
+    }
+
+    private func send(_ command: RobotCommand) {
+        switch command {
+        case .text(let message):
+            bleManager.send(message)
+        case .roombaBytes(let bytes):
+            bleManager.sendRoombaBytes(bytes)
+        }
+    }
+
+    private func resetState(for profile: RobotProfile) {
+        suppressModeCommand = true
+        selectedModeID = profile.defaultMode?.id ?? ""
+
+        quickActionStates = [:]
+        for action in profile.quickActions {
+            if case let .toggle(defaultState, _, _) = action.type {
+                quickActionStates[action.id] = defaultState
+            }
+        }
+
+        roombaMotorStates = [:]
+        if profile == .roomba {
+            for motor in RobotMotorKind.allCases {
+                roombaMotorStates[motor] = false
+            }
+        }
+
+        DispatchQueue.main.async {
+            suppressModeCommand = false
+        }
     }
 }
 
-
 #Preview {
-    ControllerView(bleManager: BluetoothManager())
+    let manager = BluetoothManager()
+    manager.selectedProfile = .roomba
+    return ControllerView(bleManager: manager)
 }

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/SettingsView.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/SettingsView.swift
@@ -10,10 +10,12 @@ import SwiftUI
 struct SettingsView: View {
     @ObservedObject var bleManager: BluetoothManager
     @State private var deviceFilter: String
+    @State private var selectedProfile: RobotProfile
 
     init(bleManager: BluetoothManager) {
         self._bleManager = ObservedObject(wrappedValue: bleManager)
         self._deviceFilter = State(initialValue: bleManager.deviceName)
+        self._selectedProfile = State(initialValue: bleManager.selectedProfile)
     }
 
     var body: some View {
@@ -28,19 +30,39 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Controller Preset") {
+                Picker("Active preset", selection: $selectedProfile) {
+                    ForEach(RobotProfile.allCases) { profile in
+                        Text(profile.displayName).tag(profile)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                Text(selectedProfile.description)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+
             Section {
                 Button("Reset to Default") {
                     deviceFilter = "ESP32Roomba"
+                    selectedProfile = .roomba
                 }
             }
         }
         .navigationTitle("Settings")
         .onAppear {
             deviceFilter = bleManager.deviceName
+            selectedProfile = bleManager.selectedProfile
         }
         .onChange(of: deviceFilter) { newValue in
             if bleManager.deviceName != newValue {
                 bleManager.deviceName = newValue
+            }
+        }
+        .onChange(of: selectedProfile) { newValue in
+            if bleManager.selectedProfile != newValue {
+                bleManager.selectedProfile = newValue
             }
         }
     }


### PR DESCRIPTION
## Summary
- add RobotProfile definitions for universal, Roomba, and tank controllers with mode and quick action metadata
- expose preset selection in the settings screen and connecting view so users can switch robot profiles before driving
- refactor the controller to render quick actions from the active preset and send the proper commands for each robot

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dc2f9578888325ad3b32f9c166857a