### PR TITLE
Add preset-driven controller view and preset management

### DIFF
--- a/App/iOS/Esp32 Controller/Esp32 Controller/Resources/BluetoothManager.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/Resources/BluetoothManager.swift
@@ -182,19 +182,24 @@ class BluetoothManager: NSObject, ObservableObject, CBCentralManagerDelegate, CB
         }
     }
 
+    // MARK: -Commands
     func sendRoombaBytes(_ bytes: [UInt8]) {
         for byte in bytes {
             send("C:\(byte)")
             usleep(10000) // 10 ms pause between each send
         }
     }
-
+    // Sending command A-F, F1-4
+    func sendCommand(_ command: String) {
+        print("Send command. Recived: \(command)")
+        send("C:\(command)")
+    }
+    // Sends the actual message
     func send(_ message: String) {
         if connectedDevice?.isSimulated == true {
             print("🤖 Simulated send: \(message)")
             return
         }
-
         if espPeripheral == nil {
             print("❌ No connected peripheral.")
         }

--- a/App/iOS/Esp32 Controller/Esp32 Controller/Resources/Models/ControllerPreset.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/Resources/Models/ControllerPreset.swift
@@ -1,6 +1,17 @@
 import Foundation
 
 struct ControllerPreset: Codable, Identifiable, Equatable {
+    let id: String
+    let name: String
+    let isDefault: Bool
+
+    let joystick1: Bool
+    let trackpad1: Bool
+    let trackpad2: Bool
+
+    let buttons: [ActionButton]
+    
+    
     struct ActionButton: Codable, Identifiable, Equatable {
         let id: String
         let title: String
@@ -37,20 +48,10 @@ struct ControllerPreset: Codable, Identifiable, Equatable {
             self.isToggle = isToggle
         }
     }
-
-    let id: String
-    let name: String
-    let isDefault: Bool
-
-    let joystick1: Bool
-    let trackpad1: Bool
-    let trackpad2: Bool
-
-    let buttons: [ActionButton]
 }
 
 extension ControllerPreset {
-    static let roombaMotorToggleGroup = "roomba.motors"
+    static let roombaMotorToggleGroup = "vacuum.motors"
 
     static let builtInPresets: [ControllerPreset] = [
         ControllerPreset(
@@ -61,12 +62,12 @@ extension ControllerPreset {
             trackpad1: false,
             trackpad2: false,
             buttons: [
-                ActionButton(id: "btn.a", title: "A", buttonColorName: "blue", sendMessage: "BTN_A"),
-                ActionButton(id: "btn.b", title: "B", buttonColorName: "green", sendMessage: "BTN_B"),
-                ActionButton(id: "btn.c", title: "C", buttonColorName: "orange", sendMessage: "BTN_C"),
-                ActionButton(id: "btn.d", title: "D", buttonColorName: "purple", sendMessage: "BTN_D"),
-                ActionButton(id: "btn.e", title: "E", buttonColorName: "pink", sendMessage: "BTN_E"),
-                ActionButton(id: "btn.f", title: "F", buttonColorName: "gray", sendMessage: "BTN_F")
+                ActionButton(id: "btn.a", title: "A", buttonColorName: "blue", sendMessage: "A"),
+                ActionButton(id: "btn.b", title: "B", buttonColorName: "green", sendMessage: "B"),
+                ActionButton(id: "btn.c", title: "C", buttonColorName: "orange", sendMessage: "C"),
+                ActionButton(id: "btn.d", title: "D", buttonColorName: "purple", sendMessage: "D"),
+                ActionButton(id: "btn.e", title: "E", buttonColorName: "pink", sendMessage: "E"),
+                ActionButton(id: "btn.f", title: "F", buttonColorName: "gray", sendMessage: "F")
             ]
         ),
         ControllerPreset(
@@ -77,54 +78,12 @@ extension ControllerPreset {
             trackpad1: false,
             trackpad2: false,
             buttons: [
-                ActionButton(
-                    id: "rv.dock",
-                    title: "Dock",
-                    iconSystemName: "house",
-                    buttonColorName: "teal",
-                    roombaBytes: [143]
-                ),
-                ActionButton(
-                    id: "rv.spot",
-                    title: "Spot",
-                    iconSystemName: "sparkles",
-                    buttonColorName: "yellow",
-                    roombaBytes: [134]
-                ),
-                ActionButton(
-                    id: "rv.clean",
-                    title: "Clean",
-                    iconSystemName: "play.fill",
-                    buttonColorName: "green",
-                    roombaBytes: [135]
-                ),
-                ActionButton(
-                    id: "rv.vacuum",
-                    title: "Vacuum",
-                    iconSystemName: "tornado",
-                    buttonColorName: "gray",
-                    roombaMotorBitMask: 0b010,
-                    toggleGroup: ControllerPreset.roombaMotorToggleGroup,
-                    isToggle: true
-                ),
-                ActionButton(
-                    id: "rv.side-brush",
-                    title: "Side",
-                    iconSystemName: "fan",
-                    buttonColorName: "gray",
-                    roombaMotorBitMask: 0b001,
-                    toggleGroup: ControllerPreset.roombaMotorToggleGroup,
-                    isToggle: true
-                ),
-                ActionButton(
-                    id: "rv.main-brush",
-                    title: "Main",
-                    iconSystemName: "paintbrush",
-                    buttonColorName: "gray",
-                    roombaMotorBitMask: 0b100,
-                    toggleGroup: ControllerPreset.roombaMotorToggleGroup,
-                    isToggle: true
-                )
+                ActionButton(id: "rv.dock", title: "Dock", iconSystemName: "house", buttonColorName: "teal", sendMessage: "A"),
+                ActionButton(id: "rv.spot", title: "Spot", iconSystemName: "sparkles", buttonColorName: "yellow", sendMessage: "B"),
+                ActionButton(id: "rv.clean", title: "Clean", iconSystemName: "play.fill", buttonColorName: "green", sendMessage: "C"),
+                ActionButton(id: "rv.vacuum", title: "Vacuum", iconSystemName: "tornado", buttonColorName: "gray", sendMessage: "D"),
+                ActionButton(id: "rv.side-brush", title: "Side", iconSystemName: "fan", buttonColorName: "gray", sendMessage: "E"),
+                ActionButton(id: "rv.main-brush", title: "Main", iconSystemName: "paintbrush", buttonColorName: "gray", sendMessage: "F")
             ]
         )
     ]

--- a/App/iOS/Esp32 Controller/Esp32 Controller/Resources/Models/ControllerPreset.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/Resources/Models/ControllerPreset.swift
@@ -1,20 +1,139 @@
 import Foundation
 
-struct ControllerPreset: Codable {
+struct ControllerPreset: Codable, Identifiable, Equatable {
+    struct ActionButton: Codable, Identifiable, Equatable {
+        let id: String
+        let title: String
+        let isVisible: Bool
+        let iconSystemName: String?
+        let buttonColorName: String?
+        let sendMessage: String?
+        let roombaBytes: [UInt8]?
+        let roombaMotorBitMask: UInt8?
+        let toggleGroup: String?
+        let isToggle: Bool
+
+        init(
+            id: String,
+            title: String,
+            isVisible: Bool = true,
+            iconSystemName: String? = nil,
+            buttonColorName: String? = nil,
+            sendMessage: String? = nil,
+            roombaBytes: [UInt8]? = nil,
+            roombaMotorBitMask: UInt8? = nil,
+            toggleGroup: String? = nil,
+            isToggle: Bool = false
+        ) {
+            self.id = id
+            self.title = title
+            self.isVisible = isVisible
+            self.iconSystemName = iconSystemName
+            self.buttonColorName = buttonColorName
+            self.sendMessage = sendMessage
+            self.roombaBytes = roombaBytes
+            self.roombaMotorBitMask = roombaMotorBitMask
+            self.toggleGroup = toggleGroup
+            self.isToggle = isToggle
+        }
+    }
+
     let id: String
     let name: String
     let isDefault: Bool
-    
+
     let joystick1: Bool
     let trackpad1: Bool
     let trackpad2: Bool
-    
-    let buttons: [button]
-    
-    struct button: Codable {
-        let isVisible: Bool
-        let name: String?
-        let imageSysname: String?
-        let buttonColor: String?
+
+    let buttons: [ActionButton]
+}
+
+extension ControllerPreset {
+    static let roombaMotorToggleGroup = "roomba.motors"
+
+    static let builtInPresets: [ControllerPreset] = [
+        ControllerPreset(
+            id: "default",
+            name: "Default",
+            isDefault: true,
+            joystick1: true,
+            trackpad1: false,
+            trackpad2: false,
+            buttons: [
+                ActionButton(id: "btn.a", title: "A", buttonColorName: "blue", sendMessage: "BTN_A"),
+                ActionButton(id: "btn.b", title: "B", buttonColorName: "green", sendMessage: "BTN_B"),
+                ActionButton(id: "btn.c", title: "C", buttonColorName: "orange", sendMessage: "BTN_C"),
+                ActionButton(id: "btn.d", title: "D", buttonColorName: "purple", sendMessage: "BTN_D"),
+                ActionButton(id: "btn.e", title: "E", buttonColorName: "pink", sendMessage: "BTN_E"),
+                ActionButton(id: "btn.f", title: "F", buttonColorName: "gray", sendMessage: "BTN_F")
+            ]
+        ),
+        ControllerPreset(
+            id: "robot-vacuum",
+            name: "Robot Vacuum",
+            isDefault: false,
+            joystick1: true,
+            trackpad1: false,
+            trackpad2: false,
+            buttons: [
+                ActionButton(
+                    id: "rv.dock",
+                    title: "Dock",
+                    iconSystemName: "house",
+                    buttonColorName: "teal",
+                    roombaBytes: [143]
+                ),
+                ActionButton(
+                    id: "rv.spot",
+                    title: "Spot",
+                    iconSystemName: "sparkles",
+                    buttonColorName: "yellow",
+                    roombaBytes: [134]
+                ),
+                ActionButton(
+                    id: "rv.clean",
+                    title: "Clean",
+                    iconSystemName: "play.fill",
+                    buttonColorName: "green",
+                    roombaBytes: [135]
+                ),
+                ActionButton(
+                    id: "rv.vacuum",
+                    title: "Vacuum",
+                    iconSystemName: "tornado",
+                    buttonColorName: "gray",
+                    roombaMotorBitMask: 0b010,
+                    toggleGroup: ControllerPreset.roombaMotorToggleGroup,
+                    isToggle: true
+                ),
+                ActionButton(
+                    id: "rv.side-brush",
+                    title: "Side",
+                    iconSystemName: "fan",
+                    buttonColorName: "gray",
+                    roombaMotorBitMask: 0b001,
+                    toggleGroup: ControllerPreset.roombaMotorToggleGroup,
+                    isToggle: true
+                ),
+                ActionButton(
+                    id: "rv.main-brush",
+                    title: "Main",
+                    iconSystemName: "paintbrush",
+                    buttonColorName: "gray",
+                    roombaMotorBitMask: 0b100,
+                    toggleGroup: ControllerPreset.roombaMotorToggleGroup,
+                    isToggle: true
+                )
+            ]
+        )
+    ]
+
+    static var defaultPreset: ControllerPreset {
+        builtInPresets.first(where: { $0.isDefault }) ?? builtInPresets[0]
+    }
+
+    static func preset(withID id: String) -> ControllerPreset {
+        builtInPresets.first(where: { $0.id == id }) ?? defaultPreset
     }
 }

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/ConnectingView.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/ConnectingView.swift
@@ -193,6 +193,25 @@ struct ConnectingView: View {
                             .disabled(!bleManager.isConnected)
                     }.padding(.trailing)
 
+                    HStack {
+                        Spacer()
+
+                        NavigationLink {
+                            ControllerPresetView(bleManager: bleManager)
+                        } label: {
+                            Text("Drive (Preset)")
+                                .foregroundStyle(.black)
+                                .font(.title3)
+                                .bold()
+                                .padding(.horizontal)
+                                .padding(.vertical, 10)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.blue)
+                        .disabled(!bleManager.isConnected)
+                    }
+                    .padding(.trailing)
+
                 }.frame(maxWidth: .infinity)
             }.padding()
                 .edgesIgnoringSafeArea(.all)

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/ControllerPresetView.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/ControllerPresetView.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+
+struct ControllerPresetView: View {
+    @ObservedObject var bleManager: BluetoothManager
+    @AppStorage("controllerPreset.id") private var selectedPresetID: String = ControllerPreset.defaultPreset.id
+
+    @State private var toggledButtons: Set<String> = []
+
+    private var preset: ControllerPreset {
+        ControllerPreset.preset(withID: selectedPresetID)
+    }
+
+    private var roombaToggleButtons: [ControllerPreset.ActionButton] {
+        preset.buttons.filter { $0.toggleGroup == ControllerPreset.roombaMotorToggleGroup }
+    }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            header
+
+            if preset.joystick1 {
+                JoystickView { command in
+                    bleManager.send(command)
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+            }
+
+            if !visibleButtons.isEmpty {
+                buttonGrid
+            } else {
+                Text("This preset does not define any buttons.")
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .navigationTitle("\(preset.name) Preset")
+        .onChange(of: selectedPresetID) { _, _ in
+            toggledButtons.removeAll()
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            if bleManager.isConnected {
+                Label("Connected", systemImage: "wifi")
+                    .font(.headline)
+                    .foregroundStyle(.green)
+            } else {
+                Label("Disconnected", systemImage: "wifi.slash")
+                    .font(.headline)
+                    .foregroundStyle(.red)
+            }
+
+            Spacer()
+
+            Text(preset.name)
+                .font(.title3)
+                .bold()
+
+            Spacer()
+
+            Button {
+                if bleManager.isConnected {
+                    bleManager.checkConnection()
+                } else {
+                    bleManager.startScan()
+                }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.title2)
+            }
+            .buttonStyle(.bordered)
+        }
+    }
+
+    private var buttonGrid: some View {
+        let columns: [GridItem] = Array(repeating: GridItem(.flexible(), spacing: 16), count: 3)
+
+        return LazyVGrid(columns: columns, spacing: 16) {
+            ForEach(visibleButtons) { button in
+                Button {
+                    handleButtonTap(button)
+                } label: {
+                    VStack(spacing: 8) {
+                        if let icon = button.iconSystemName {
+                            Image(systemName: iconName(for: button))
+                                .font(.system(size: 28, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .padding(12)
+                                .background(buttonBackground(for: button))
+                                .clipShape(Circle())
+                        } else {
+                            Text(button.title)
+                                .font(.title3.bold())
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 18)
+                                .background(buttonBackground(for: button))
+                                .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                                .foregroundStyle(.white)
+                        }
+
+                        if button.iconSystemName != nil {
+                            Text(button.title)
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(12)
+                    .background(toggledButtons.contains(button.id) ? Color.accentColor.opacity(0.15) : Color(.systemGray6))
+                    .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                }
+                .disabled(!bleManager.isConnected)
+            }
+        }
+    }
+
+    private var visibleButtons: [ControllerPreset.ActionButton] {
+        preset.buttons.filter { $0.isVisible }
+    }
+
+    private func handleButtonTap(_ button: ControllerPreset.ActionButton) {
+        if button.isToggle {
+            if toggledButtons.contains(button.id) {
+                toggledButtons.remove(button.id)
+            } else {
+                toggledButtons.insert(button.id)
+            }
+        }
+
+        if let message = button.sendMessage {
+            bleManager.send(message)
+        }
+
+        if let bytes = button.roombaBytes {
+            bleManager.sendRoombaBytes(bytes)
+        }
+
+        if let group = button.toggleGroup, group == ControllerPreset.roombaMotorToggleGroup {
+            let bits = roombaToggleButtons
+                .filter { toggledButtons.contains($0.id) }
+                .reduce(UInt8(0)) { partialResult, action in
+                    partialResult + (action.roombaMotorBitMask ?? 0)
+                }
+            bleManager.sendRoombaBytes([138, bits])
+        }
+    }
+
+    private func iconName(for button: ControllerPreset.ActionButton) -> String {
+        if button.isToggle, let icon = button.iconSystemName {
+            if toggledButtons.contains(button.id) {
+                switch icon {
+                case "fan": return "fan.fill"
+                case "paintbrush": return "paintbrush.fill"
+                case "tornado": return "tornado"
+                default: return icon
+                }
+            }
+        }
+        return button.iconSystemName ?? "circle"
+    }
+
+    private func buttonBackground(for button: ControllerPreset.ActionButton) -> Color {
+        let baseColor: Color
+        switch button.buttonColorName?.lowercased() {
+        case "blue": baseColor = .blue
+        case "green": baseColor = .green
+        case "orange": baseColor = .orange
+        case "purple": baseColor = .purple
+        case "pink": baseColor = .pink
+        case "teal": baseColor = .teal
+        case "yellow": baseColor = .yellow
+        case "gray": baseColor = Color(.systemGray4)
+        default: baseColor = .accentColor
+        }
+
+        if button.isToggle {
+            return toggledButtons.contains(button.id) ? baseColor : baseColor.opacity(0.5)
+        }
+        return baseColor
+    }
+}
+
+#Preview {
+    ControllerPresetView(bleManager: BluetoothManager())
+}

--- a/App/iOS/Esp32 Controller/Esp32 Controller/View/Controlllll.swift
+++ b/App/iOS/Esp32 Controller/Esp32 Controller/View/Controlllll.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+struct Controlllll: View {
+    @ObservedObject var bleManager: BluetoothManager
+    @AppStorage("controllerPreset.id") private var selectedPresetID: String = ControllerPreset.defaultPreset.id
+
+    @State private var toggledButtons: Set<String> = []
+
+    private var preset: ControllerPreset {
+        ControllerPreset.preset(withID: selectedPresetID)
+    }
+
+    private var roombaToggleButtons: [ControllerPreset.ActionButton] {
+        preset.buttons.filter { $0.toggleGroup == ControllerPreset.roombaMotorToggleGroup }
+    }
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            // Header
+            HStack {
+                Spacer()
+                if bleManager.isConnected {
+                    HStack(spacing: 0) {
+                        Image(systemName: "wifi")
+                            .font(.title2)
+                            .foregroundStyle(.green)
+                        Text("Connected")
+                            .font(.title3)
+                            .foregroundStyle(.green)
+                    }
+                } else {
+                    HStack(spacing: 0) {
+                        Image(systemName: "wifi.slash")
+                            .font(.title2)
+                            .foregroundStyle(.red)
+                        Text("Disconnected")
+                            .font(.title3)
+                            .foregroundStyle(.red)
+                    }
+                }
+                Spacer()
+            }
+            Spacer()
+            // Main controll
+            HStack {
+                JoystickView { command in
+                    bleManager.send(command)
+                }
+                Spacer()
+                VStack {
+                    Spacer()
+                    Button {
+                        bleManager.sendCommand("Reset")
+                    } label: {
+                        ZStack {
+                            Text("Reset")
+                                .font(.largeTitle)
+                                .bold()
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 9)
+                        }.background(.red)
+                            .cornerRadius(8)
+                    }
+                }
+                Spacer()
+                VStack(spacing: 0) {
+                    HStack {
+                        Button {
+                            bleManager.sendCommand("B")
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .frame(width: 70)
+                                    .foregroundStyle(.yellow)
+                                Text("B")
+                                    .font(.system(size: 45, weight: .bold))
+                                    .foregroundStyle(.black)
+                            }
+                        }
+                    }
+                    // Second Row
+                    HStack {
+                        Button {
+                            bleManager.sendCommand("A")
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .frame(width: 70)
+                                    .foregroundStyle(.red)
+                                Text("A")
+                                    .font(.system(size: 45, weight: .bold))
+                                    .foregroundStyle(.black)
+                            }.padding(.trailing)
+                        }
+                        
+                        Button {
+                            bleManager.sendCommand("D")
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .frame(width: 70)
+                                    .foregroundStyle(.green)
+                                Text("D")
+                                    .font(.system(size: 45, weight: .bold))
+                                    .foregroundStyle(.black)
+                            }.padding(.leading)
+                        }
+                    }
+                    // Third row
+                    HStack {
+                        Button {
+                            bleManager.sendCommand("C")
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .frame(width: 70)
+                                    .foregroundStyle(.blue)
+                                Text("C")
+                                    .font(.system(size: 45, weight: .bold))
+                                    .foregroundStyle(.black)
+                            }
+                        }
+                    }
+                }
+            }
+            
+        }
+        .padding([.top])
+        .navigationTitle("\(preset.name) Preset")
+        .onChange(of: selectedPresetID) { _, _ in
+            toggledButtons.removeAll()
+        }
+    }
+}
+
+
+#Preview {
+    Controlllll(bleManager: BluetoothManager())
+}
+

--- a/ESP32/Roomba/ESPScript/ESPScript_copy.ino
+++ b/ESP32/Roomba/ESPScript/ESPScript_copy.ino
@@ -1,0 +1,105 @@
+#include <BLEDevice.h>
+#include <BLEServer.h>
+#include <BLEUtils.h>
+#include <BLE2902.h>
+
+#define SERVICE_UUID           "12345678-1234-5678-1234-56789abcdef0"
+#define CHARACTERISTIC_UUID    "abcdef01-1234-5678-1234-56789abcdef0"
+
+#define ROOMBA_TX 17
+#define ROOMBA_RX 16
+#define DETECT_PIN 15  // optional pin to reset/wake Roomba
+
+// Setup of BLE
+void setup() {
+  Serial.begin(115200);
+  Serial1.begin(115200, SERIAL_8N1, ROOMBA_RX, ROOMBA_TX);
+
+  // Optional: wake Roomba using detect pin
+  pinMode(DETECT_PIN, OUTPUT);
+  digitalWrite(DETECT_PIN, LOW); delay(100);
+  digitalWrite(DETECT_PIN, HIGH); delay(1000);
+
+  // Roomba start + safe mode
+  Serial1.write(128); delay(20);  // START
+  Serial1.write(131); delay(20);  // SAFE
+
+  // BLE setup
+  BLEDevice::init("ESP32Roomba");
+  BLEServer *pServer = BLEDevice::createServer();
+  BLEService *pService = pServer->createService(SERVICE_UUID);
+
+  BLECharacteristic *pCharacteristic = pService->createCharacteristic(
+    CHARACTERISTIC_UUID,
+    BLECharacteristic::PROPERTY_WRITE
+  );
+
+  pCharacteristic->setCallbacks(new MyCallbacks());
+
+  pService->start();
+
+  BLEAdvertising *pAdvertising = BLEDevice::getAdvertising();
+  pAdvertising->addServiceUUID(SERVICE_UUID);
+  pAdvertising->start();
+
+  Serial.println("🚀 BLE Ready — connect and send joystick data");
+}
+
+void sendDriveCommand(int velocity, int radius) {
+  Serial.print("🚗 Sending Roomba drive → velocity: ");
+  Serial.print(velocity);
+  Serial.print("  radius: ");
+  Serial.println(radius);
+
+  Serial1.write(137);
+  Serial1.write((velocity >> 8) & 0xFF);
+  Serial1.write(velocity & 0xFF);
+  Serial1.write((radius >> 8) & 0xFF);
+  Serial1.write(radius & 0xFF);
+}
+
+class MyCallbacks : public BLECharacteristicCallbacks {
+  void onWrite(BLECharacteristic *pCharacteristic) {
+    String value = pCharacteristic->getValue();
+    Serial.print("📩 Received: ");
+    Serial.println(value);
+
+    // Expect format: V:<velocity> R:<radius>
+    if (value.startsWith("V:")) {
+      int vIndex = value.indexOf("V:");
+      int rIndex = value.indexOf("R:");
+
+      if (vIndex == -1 || rIndex == -1) {
+        Serial.println("❌ Invalid format");
+        return;
+      }
+
+      // Extract substrings
+      String vPart = value.substring(vIndex + 2, rIndex - 1);
+      String rPart = value.substring(rIndex + 2);
+
+      int velocity = vPart.toInt();
+      int radius = rPart.toInt();
+
+      Serial.print("✅ Parsed → V: "); Serial.print(velocity);
+      Serial.print(" R: "); Serial.println(radius);
+
+      sendDriveCommand(velocity, radius);
+    };
+    // Expect commands => C:
+    if (value.startsWith("C:")) {
+      String byteStr = value.substring(2);
+      byteStr.trim();
+
+      int byteVal = byteStr.toInt();
+      Serial.print("📤 Sending byte: ");
+      Serial.println(byteVal);
+
+      Serial1.write(byteVal);
+    }
+  }
+};
+
+void loop() {
+  // no loop logic needed
+}


### PR DESCRIPTION
## Summary
- expand the controller preset model with built-in default and robot vacuum layouts
- persist preset selection from settings and show helpful descriptions
- add a new preset-based controller view alongside the existing controller screen

## Testing
- not run (iOS project)

------
https://chatgpt.com/codex/tasks/task_e_68e165b518d08325a790da947d92a7be